### PR TITLE
add new mpich versions, remove "preferred" tag

### DIFF
--- a/packages/mpich/package.py
+++ b/packages/mpich/package.py
@@ -1,7 +1,10 @@
 from spack.pkg.builtin.mpich import Mpich
 
 class Mpich(Mpich):
-    version('3.3.2', default=True, preferred=True, sha256='4bfaf8837a54771d3e4922c84071ef80ffebddbb6971a006038d91ee7ef959b9')
+    version('3.4.2', sha256='5c19bea8b84e8d74cca5f047e82b147ff3fba096144270e3911ad623d6c587bf')
+    version('3.4.1', sha256='8836939804ef6d492bcee7d54abafd6477d2beca247157d92688654d13779727')
+    version('3.4',   sha256='ce5e238f0c3c13ab94a64936060cff9964225e3af99df1ea11b130f20036c24b')
+    version('3.3.2', sha256='4bfaf8837a54771d3e4922c84071ef80ffebddbb6971a006038d91ee7ef959b9')
     version('3.4.benvolio', branch='benvolio', git="https://github.com/roblatham00/mpich.git", submodules=True,
              preferred=False)
 


### PR DESCRIPTION
- this still makes newer versions of mpich available, but removing the
  preferred tag prevents it from holding back environments with newere
  upstream versions available