### PR TITLE
add explicit autoreconf step to all autotools packages

### DIFF
--- a/packages/benvolio/package.py
+++ b/packages/benvolio/package.py
@@ -38,6 +38,14 @@ class Benvolio(AutotoolsPackage):
     #depends_on('mochi-thallium@develop', when='@develop')
     #depends_on('mochi-ssg+mpi@develop', when='@develop')
 
+    # NOTE: The default autoreconf steps should work fine for this package.
+    #       The explicit definition is just here as a workaround; Spack's
+    #       default autoreconf step is prone to libtool version mismatch as
+    #       of 2021/10/20.
+    def autoreconf(self, spec, prefix):
+        sh = which('sh')
+        sh('-c', 'autoreconf -fi')
+
     # Require a custom configure_args if we need to build with MPI wrapper
 
     def configure_args(self):

--- a/packages/mobject/package.py
+++ b/packages/mobject/package.py
@@ -75,6 +75,14 @@ class Mobject(AutotoolsPackage):
 
     patch('0001-crude-timing-information.patch', when='+timing @:0.4.1')
 
+    # NOTE: The default autoreconf steps should work fine for this package.
+    #       The explicit definition is just here as a workaround; Spack's
+    #       default autoreconf step is prone to libtool version mismatch as
+    #       of 2021/10/20.
+    def autoreconf(self, spec, prefix):
+        sh = which('sh')
+        sh('./prepare.sh')
+
     def configure_args(self):
         extra_args = []
         if self.version < Version('0.5'):

--- a/packages/mochi-abt-io/package.py
+++ b/packages/mochi-abt-io/package.py
@@ -48,3 +48,11 @@ class MochiAbtIo(AutotoolsPackage):
     depends_on('libtool', type=("build"))
     depends_on('pkgconfig', type=("build"))
     depends_on('openssl', type=("build", "link", "run"))
+
+    # NOTE: The default autoreconf steps should work fine for this package.
+    #       The explicit definition is just here as a workaround; Spack's
+    #       default autoreconf step is prone to libtool version mismatch as
+    #       of 2021/10/20.
+    def autoreconf(self, spec, prefix):
+        sh = which('sh')
+        sh('./prepare.sh')

--- a/packages/mochi-bake/package.py
+++ b/packages/mochi-bake/package.py
@@ -57,6 +57,14 @@ class MochiBake(AutotoolsPackage):
     conflicts('+bedrock', when='@:0.5',
               msg='+bedrock variant only available starting from 0.6')
 
+    # NOTE: The default autoreconf steps should work fine for this package.
+    #       The explicit definition is just here as a workaround; Spack's
+    #       default autoreconf step is prone to libtool version mismatch as
+    #       of 2021/10/20.
+    def autoreconf(self, spec, prefix):
+        sh = which('sh')
+        sh('./prepare.sh')
+
     def configure_args(self):
         spec = self.spec
         extra_args = []

--- a/packages/mochi-ch-placement/package.py
+++ b/packages/mochi-ch-placement/package.py
@@ -41,3 +41,10 @@ class MochiChPlacement(AutotoolsPackage):
     depends_on('automake')
     depends_on('libtool')
 
+    # NOTE: The default autoreconf steps should work fine for this package.
+    #       The explicit definition is just here as a workaround; Spack's
+    #       default autoreconf step is prone to libtool version mismatch as
+    #       of 2021/10/20.
+    def autoreconf(self, spec, prefix):
+        sh = which('sh')
+        sh('./prepare')

--- a/packages/mochi-poesie/package.py
+++ b/packages/mochi-poesie/package.py
@@ -49,6 +49,14 @@ class MochiPoesie(AutotoolsPackage):
     depends_on('lua', when="+lua")
     depends_on('python', when="+python")
 
+    # NOTE: The default autoreconf steps should work fine for this package.
+    #       The explicit definition is just here as a workaround; Spack's
+    #       default autoreconf step is prone to libtool version mismatch as
+    #       of 2021/10/20.
+    def autoreconf(self, spec, prefix):
+        sh = which('sh')
+        sh('./prepare.sh')
+
     def configure_args(self):
         spec = self.spec
         extra_args = []

--- a/packages/mochi-sdskv/package.py
+++ b/packages/mochi-sdskv/package.py
@@ -84,6 +84,13 @@ class MochiSdskv(AutotoolsPackage):
     # (see https://github.com/google/leveldb/issues/891)
     depends_on('leveldb@:1.22', when="+leveldb")
 
+    # NOTE: The default autoreconf steps should work fine for this package.
+    #       The explicit definition is just here as a workaround; Spack's
+    #       default autoreconf step is prone to libtool version mismatch as
+    #       of 2021/10/20.
+    def autoreconf(self, spec, prefix):
+        sh = which('sh')
+        sh('./prepare.sh')
 
     def configure_args(self):
         spec = self.spec

--- a/packages/mochi-ssg/package.py
+++ b/packages/mochi-ssg/package.py
@@ -51,6 +51,14 @@ class MochiSsg(AutotoolsPackage):
     depends_on('mochi-margo@0.6:', when='@0.4.1:')
     depends_on('mochi-margo@develop', when='@develop')
 
+    # NOTE: The default autoreconf steps should work fine for this package.
+    #       The explicit definition is just here as a workaround; Spack's
+    #       default autoreconf step is prone to libtool version mismatch as
+    #       of 2021/10/20.
+    def autoreconf(self, spec, prefix):
+        sh = which('sh')
+        sh('./prepare.sh')
+
     def configure_args(self):
         spec = self.spec
         extra_args = []


### PR DESCRIPTION
- this is a workaround to an apperent spack bug; the default autoreconf step sometimes produces a libtool version mismatch