### PR TITLE
explicitly disable pmix in mochi-ssg if ~pmix

### DIFF
--- a/packages/mochi-ssg/package.py
+++ b/packages/mochi-ssg/package.py
@@ -72,9 +72,14 @@ class MochiSsg(AutotoolsPackage):
                 "--enable-mpi",
                 "CC=%s" % spec['mpi'].mpicc
                 ])
-        elif '+pmix' in spec:
+
+        if '+pmix' in spec:
             extra_args.extend([
                 "--enable-pmix"
+                ])
+        else:
+            extra_args.extend([
+                "--disable-pmix"
                 ])
 
         if '+drc' in spec:


### PR DESCRIPTION
- spack package will now explicitly either --enable-pmix or --disable-pmix
  depending on variants, so that pmix can be intentionally disabled on systems
  where it is problematic
- also made +mpi and +pmix not mutually exclusive in case we want a build
  with both in the future for some reason

fixes #6 